### PR TITLE
Put request.name in LowerCase

### DIFF
--- a/dns.js
+++ b/dns.js
@@ -58,7 +58,7 @@ RainbowDns.prototype.respond = function(request, response, results) {
 }
 RainbowDns.prototype.handleRequest = function (request, response) {
     var _request     = request.question[0]
-    var query        = _request.name
+    var query        = (_request.name).toLowerCase()
     var answer_types = this.filterTypes(this.pickAnswerTypes(_request.type))
     this.queryStore(query, answer_types, function(results) {
         if (results.length == 0 && this.fwdserver) 


### PR DESCRIPTION
We wanted use your DNS server for auto Let's Encrypt dns01 challenge validation but requests with Upercases doesn't work. 

So, force the request.name in lowerCase solve the problem.

Thanks for you app @asbjornenge. 